### PR TITLE
Fixed incorrect "Zoom" --> "zoom" from json

### DIFF
--- a/src/Cyjs.NET/Html.fs
+++ b/src/Cyjs.NET/Html.fs
@@ -61,7 +61,7 @@ module HTML =
         cy.container <- PlainJsonString id
 
         let userZoomingEnabled =
-            match cy.TryGetTypedValue<Zoom> "Zoom"  with
+            match cy.TryGetTypedValue<Zoom> "zoom"  with
             | Some z -> 
                 match z.TryGetTypedValue<bool> "zoomingEnabled" with
                 | Some t -> t


### PR DESCRIPTION
Cyjs.NET produces a JSON that contains a "zoom" element, not a "Zoom" element. Thus, userZoomingEnabled was always false when producing the HTML.