### PR TITLE
Adding discord chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Cyjs.NET
+
+[![Discord](https://img.shields.io/discord/836161044501889064?color=purple&label=Join%20our%20Discord%21&logo=discord&logoColor=white)](https://discord.gg/qbN5v8WvfR)
+
 .NET interface for Cytoscape.js written in F#


### PR DESCRIPTION
As I have discussed with @kMutagene , this might greatly improve communications among new users of the projects, contributors, and maintainers.

The link leads to a dedicated #cyjs-net channel, but all other channels within the FsLab server are still available for all newcomers.